### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/rag/batch/src/embeddings-models.ts
+++ b/rag/batch/src/embeddings-models.ts
@@ -9,7 +9,7 @@ interface EmbeddingsModel {
 }
 
 function listEmbeddings(): EmbeddingsModel[] {
-  console.log(JSON.stringify(process.env.AZURE_OPENAI_API_KEY ?? '', null, 2));
+  // Do not log sensitive information such as API keys.
   return [
     {
       type: 'titan', model: new BedrockEmbeddings({


### PR DESCRIPTION
Potential fix for [https://github.com/poad/llm-ts-example/security/code-scanning/2](https://github.com/poad/llm-ts-example/security/code-scanning/2)

To fix the problem, we must ensure that sensitive information such as API keys is never logged, even in development. The best way to do this is to remove or comment out the line that logs `process.env.AZURE_OPENAI_API_KEY`. If logging is needed for debugging, log only non-sensitive information or a message indicating whether the key is set (without revealing its value). The change should be made in `rag/batch/src/embeddings-models.ts`, specifically on line 12. No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
